### PR TITLE
fix issue#9

### DIFF
--- a/core/server/role/revert.go
+++ b/core/server/role/revert.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/ok-chain/okchain/config"
-	"github.com/ok-chain/okchain/crypto/multibls"
 	ps "github.com/ok-chain/okchain/core/server"
+	"github.com/ok-chain/okchain/crypto/multibls"
 	pb "github.com/ok-chain/okchain/protos"
 )
 
@@ -197,13 +197,12 @@ func initShardingNodeInfo(peerServer *ps.PeerServer, dsblock *pb.DSBlock) {
 func startPowLead(r *RoleShardingLead, txblock *pb.TxBlock) error {
 	pk := multibls.PubKey{}
 	pk.Deserialize(r.peerServer.SelfNode.Pubkey)
-	miningResult, err := r.mining(pk.GetHexString(), txblock.Header.BlockNumber)
-
+	miningResult, diff, err := r.mining(pk.GetHexString(), txblock.Header.BlockNumber)
 	if err != nil {
 		return err
 	}
 
-	powSubmission := r.composePoWSubmission(miningResult, txblock.Header.BlockNumber, r.peerServer.SelfNode.Pubkey)
+	powSubmission := r.composePoWSubmission(miningResult, txblock.Header.BlockNumber, r.peerServer.SelfNode.Pubkey, diff)
 
 	loggerShardingBase.Debugf("powsubmission is %+v", powSubmission)
 
@@ -238,13 +237,12 @@ func startPowLead(r *RoleShardingLead, txblock *pb.TxBlock) error {
 func startPowBackup(r *RoleShardingBackup, txblock *pb.TxBlock) error {
 	pk := multibls.PubKey{}
 	pk.Deserialize(r.peerServer.SelfNode.Pubkey)
-	miningResult, err := r.mining(pk.GetHexString(), txblock.Header.BlockNumber)
-
+	miningResult, diff, err := r.mining(pk.GetHexString(), txblock.Header.BlockNumber)
 	if err != nil {
 		return err
 	}
 
-	powSubmission := r.composePoWSubmission(miningResult, txblock.Header.BlockNumber, r.peerServer.SelfNode.Pubkey)
+	powSubmission := r.composePoWSubmission(miningResult, txblock.Header.BlockNumber, r.peerServer.SelfNode.Pubkey, diff)
 
 	loggerShardingBase.Debugf("powsubmission is %+v", powSubmission)
 

--- a/core/server/role/role_base.go
+++ b/core/server/role/role_base.go
@@ -26,9 +26,9 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
+	ps "github.com/ok-chain/okchain/core/server"
 	logging "github.com/ok-chain/okchain/log"
 	gossip_common "github.com/ok-chain/okchain/p2p/gossip/common"
-	ps "github.com/ok-chain/okchain/core/server"
 	pb "github.com/ok-chain/okchain/protos"
 	"github.com/ok-chain/okchain/util"
 )
@@ -517,19 +517,20 @@ func (r *RoleBase) VerifyVCBlock(msg *pb.Message, from *pb.PeerEndpoint) (*pb.VC
 	return vcblock, nil
 }
 
-func (r *RoleBase) mining(pk string, blockNumber uint64) (*pb.MiningResult, error) {
+func (r *RoleBase) mining(pk string, blockNumber uint64) (*pb.MiningResult, int64, error) {
+	diff := r.peerServer.GetPowDifficulty()
 	seed := r.updateDSBlockRand() + r.updateTXBlockRand() + r.peerServer.SelfNode.Address + pk + hex.EncodeToString(r.peerServer.CoinBase)
-	miningResult, err := r.peerServer.Miner.Mine([]byte(seed), blockNumber+1, big.NewInt(r.peerServer.GetPowDifficulty()))
+	miningResult, err := r.peerServer.Miner.Mine([]byte(seed), blockNumber+1, big.NewInt(diff))
 	if err != nil {
 		logger.Errorf("mine error with seed %+v, error: %s", seed, err.Error())
-		return nil, ErrMine
+		return nil, diff, ErrMine
 	}
 	logger.Debugf("mine nonce is %d, hash is %s, resulthash is %s", miningResult.Nonce,
 		hex.EncodeToString(miningResult.MixHash), hex.EncodeToString(miningResult.PowResult))
-	return miningResult, nil
+	return miningResult, diff, nil
 }
 
-func (r *RoleBase) composePoWSubmission(miningResult *pb.MiningResult, blockNumber uint64, pubkey []byte) *pb.PoWSubmission {
+func (r *RoleBase) composePoWSubmission(miningResult *pb.MiningResult, blockNumber uint64, pubkey []byte, diff int64) *pb.PoWSubmission {
 	powSubmission := &pb.PoWSubmission{}
 	powSubmission.BlockNum = blockNumber
 	powSubmission.Nonce = miningResult.Nonce
@@ -537,7 +538,7 @@ func (r *RoleBase) composePoWSubmission(miningResult *pb.MiningResult, blockNumb
 	powSubmission.Peer = r.peerServer.SelfNode
 	powSubmission.PublicKey = pubkey
 	powSubmission.Coinbase = r.peerServer.CoinBase
-	powSubmission.Difficulty = uint64(r.peerServer.GetPowDifficulty())
+	powSubmission.Difficulty = uint64(diff)
 	powSubmission.Rand1 = r.updateDSBlockRand()
 	powSubmission.Rand2 = r.updateTXBlockRand()
 	return powSubmission

--- a/core/server/role/role_sharding_base.go
+++ b/core/server/role/role_sharding_base.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	ps "github.com/ok-chain/okchain/core/server"
 	"github.com/ok-chain/okchain/crypto/multibls"
 	logging "github.com/ok-chain/okchain/log"
-	ps "github.com/ok-chain/okchain/core/server"
 	pb "github.com/ok-chain/okchain/protos"
 )
 
@@ -139,10 +139,10 @@ func (r *RoleShardingBase) ProcessFinalBlock(pbMsg *pb.Message, from *pb.PeerEnd
 
 	r.onFinalBlockReady(txblock)
 
-	numOfSharding := len(r.peerServer.DsBlockChain().CurrentBlock().(*pb.DSBlock).Body.ShardingNodes) / r.peerServer.GetShardingSize()
-
+	curDsBlock := r.peerServer.DsBlockChain().CurrentBlock().(*pb.DSBlock)
+	numOfSharding := len(curDsBlock.Body.ShardingNodes) / r.peerServer.GetShardingSize()
 	if (numOfSharding != 0 && txblock.Header.BlockNumber%uint64(r.peerServer.GetShardingSize()) == 0) ||
-		(numOfSharding == 0 && txblock.Header.BlockNumber%uint64(len(r.peerServer.DsBlockChain().CurrentBlock().(*pb.DSBlock).Body.ShardingNodes)) == 0) {
+		(numOfSharding == 0 && txblock.Header.BlockNumber%uint64(len(curDsBlock.Body.ShardingNodes)) == 0) {
 		// start pow
 		loggerShardingBase.Debugf("start pow, waiting for find a results")
 
@@ -152,16 +152,20 @@ func (r *RoleShardingBase) ProcessFinalBlock(pbMsg *pb.Message, from *pb.PeerEnd
 		// call miner function
 		pk := multibls.PubKey{}
 		pk.Deserialize(r.peerServer.SelfNode.Pubkey)
-		miningResult, err := r.mining(pk.GetHexString(), txblock.Header.BlockNumber)
-
+		miningResult, diff, err := r.mining(pk.GetHexString(), txblock.Header.BlockNumber)
 		if err != nil {
 			return ErrMine
 		}
 
-		powSubmission := r.composePoWSubmission(miningResult, txblock.Header.BlockNumber, r.peerServer.SelfNode.Pubkey)
+		// issue#9  whether the block is updated after mining
+		newDsBlock := r.peerServer.DsBlockChain().CurrentBlock().(*pb.DSBlock)
+		if curDsBlock.NumberU64() != newDsBlock.NumberU64() {
+			idleLogger.Warningf("dsblock is updated to %d, i will ignore the PoWSubmission", newDsBlock.NumberU64())
+			return nil
+		}
 
+		powSubmission := r.composePoWSubmission(miningResult, txblock.Header.BlockNumber, r.peerServer.SelfNode.Pubkey, diff)
 		loggerShardingBase.Debugf("powsubmission is %+v", powSubmission)
-
 		data, err := proto.Marshal(powSubmission)
 		if err != nil {
 			loggerShardingBase.Errorf("PoWSubmission marshal error %s", err.Error())


### PR DESCRIPTION
某节点挖矿过程中，收到新DSblock后，curDsBlock更新。
compose PoWSubmission计算挖矿难度时使用curDsBlock获取对应的finalblock为nil，因为panic。
okchain/core/server/peer.go:1022 panic: interface conversion: protos.IBlock is nil, not *protos.TxBlock